### PR TITLE
build: flatpak: Add missing dependencies.

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.Plugin.photolayer.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.photolayer.yaml
@@ -19,8 +19,7 @@ modules:
             url: https://download.osgeo.org/proj/proj-6.3.2.tar.gz
             sha256: cb776a70f40c35579ae4ba04fb4a388c1d1ce025a1df6171350dc19f25b80311
       config-opts:
-          - --disable-static
-          - --prefix=/app/extensions
+          - --prefix=/app/extensions/photolayer
     - name: libgeotiff
       sources:
           - type: archive
@@ -28,8 +27,8 @@ modules:
             sha256: 9311017e5284cffb86f2c7b7a9df1fb5ebcdc61c30468fb2e6bca36e4272ebca
             subdir: libgeotiff
       config-opts:
-          - --disable-static
-          - --prefix=/app/extensions
+          - --with-proj=/app/extensions/photolayer
+          - --prefix=/app/extensions/photolayer
     - name: photolayer
       no-autogen: true
       buildsystem: cmake

--- a/flatpak/org.opencpn.OpenCPN.Plugin.photolayer.yaml
+++ b/flatpak/org.opencpn.OpenCPN.Plugin.photolayer.yaml
@@ -39,9 +39,8 @@ modules:
           - -DBUILD_TYPE:STRING=tarball
           - -Uplugin_target
       build-options:
-          cxxflags: -DFLATPAK -O3
-          cflags: -DFLATPAK -O3
-          # The flatpak-builder default CFLAGS adds -g
+          cxxflags: -DFLATPAK
+          cflags: -DFLATPAK
       sources:
           - type: git
             url: ..


### PR DESCRIPTION
Found some time, while looking at ongoing events i Washington... Simple fix, but I needed some help first.

Flatpak plugin now looks fine, all icons in place, "seems" to work.