### PR TITLE
Macos libs 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ debian-steps: &debian-steps
         paths:
           - /home/circleci/.local/lib
           - /home/circleci/.local/include
+    - run: sh -c "ldd  build/app/*/lib/opencpn/*.so"
     - run: cd build; /bin/bash < upload.sh
     - run: python3 ci/git-push
 
@@ -76,6 +77,7 @@ jobs:
             - /usr/local/Cellar
             - /usr/local/lib
             - /usr/local/include
+      - run: sh -c "otool -L build/app/*/OpenCPN.app/Contents/PlugIns/*.dylib"
       - run: cd build; /bin/bash < upload.sh
       - run: python3 ci/git-push
 

--- a/build-deps/macos-deps
+++ b/build-deps/macos-deps
@@ -5,8 +5,6 @@ cmake
 gettext
 libtiff
 libtool
-libexif
 pkg-config
 python
-sqlite
 wget

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -13,7 +13,7 @@ pkg_version() { brew list --versions $2 $1 | tail -1 | awk '{print $2}'; }
 
 #
 # Check if the cache is with us. If not, re-install brew.
-brew list --versions libexif || brew update-reset
+brew list --versions gettext || brew update-reset
 
 # Install packaged dependencies
 here=$(cd "$(dirname "$0")"; pwd)

--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -45,7 +45,7 @@ cmake \
   -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312B_opencpn50_macos109" \
   -DCMAKE_INSTALL_PREFIX= \
   -DGEOTIFF_INSTALL_PREFIX="/usr/local" \
-  -DUSE_SYSTEM_GEOTIFF:BOOL="OFF" \
+  -DUSE_SYSTEM_GEOTIFF:BOOL="ON" \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 \
   ..
 

--- a/libs/libtiff/CMakeLists.txt
+++ b/libs/libtiff/CMakeLists.txt
@@ -18,13 +18,18 @@ add_library(ocpn::tiff ALIAS _TIFF)
 
 if (WIN32)
   file(GLOB libtiff_dir "${CMAKE_CURRENT_SOURCE_DIR}/tiff-msvc-*")
-  add_library(_TIFF_MSCV STATIC IMPORTED)
+  add_library(_TIFF_MSVC STATIC IMPORTED)
   set_property(
-    TARGET _TIFF_MSCV
+    TARGET _TIFF_MSVC
     PROPERTY IMPORTED_LOCATION ${libtiff_dir}/libtiff.lib
   )
   target_include_directories(_TIFF INTERFACE ${libtiff_dir}/include)
-  target_link_libraries(_TIFF INTERFACE _TIFF_MSCV)
+  target_link_libraries(_TIFF INTERFACE _TIFF_MSVC)
+elseif (APPLE)
+  find_package(TIFF REQUIRED)
+  find_library(_STATIC_TIFF_LIB NAMES libtiff.a REQUIRED)
+  target_link_libraries(_TIFF INTERFACE ${_STATIC_TIFF_LIB})
+  target_include_directories(_TIFF INTERFACE ${TIFF_INCLUDE_DIRS})
 else ()
   find_package(TIFF REQUIRED)
   target_link_libraries(_TIFF INTERFACE ${TIFF_LIBRARIES})
@@ -36,5 +41,5 @@ if (UNIX AND NOT "${BUILD_TYPE}" STREQUAL "flatpak" AND NOT APPLE)
   file(GLOB _tiff_libs /usr/lib/*/libtiff.so.* /usr/lib*/libtiff.so.*)
   install(CODE
     "execute_process(COMMAND cmake -E copy ${_tiff_libs} app/files/lib)"
-   )
+  )
 endif ()


### PR DESCRIPTION
Fix the dependencies not available in runtime.
  - Drop the unused libexif and sqlite deps.
  - Link the libtiff library statically. 
 
Here is also fixes to restore the used of cached builds of proj and llibgeotiff. Finally, otool -L is run on the final plugin shared lib to display it's dependencies.

This has taken too much time :(

Closes: #29