### PR TITLE
ci: Add crippled windows ldd clone.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ build_script:
   - cd build
   - cmake -T v141_xp -G "Visual Studio 15 2017" --config RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
   - cmake --build . --target tarball --config RelWithDebInfo
+  - py ..\ci\windows-ldd
   - cmd: upload.bat
   - py ..\ci\git-push
 

--- a/ci/windows-ldd
+++ b/ci/windows-ldd
@@ -1,0 +1,13 @@
+#
+# Python script running the Visual Studio dumpbin tool on
+# the plugin dll.
+
+import subprocess
+import glob
+
+dumpbin = glob.glob(
+  "C:/Program Files (x86)/*Visual Studio/2017/Community/VC/Tools/MSVC/*/bin/Hostx64/x64")[0]
+dumpbin += "/dumpbin"
+lib = glob.glob("C:/project/opencpn/*/build/app/*/plugins/*.dll")[0]
+subprocess.run([dumpbin, "/dependents", lib])
+


### PR DESCRIPTION
As  heading says: Add a call to dumpbin as a final ci build stage, listing the dll dependencies. This is basically the same as ldd on linux and otool -L on MacOS

There is no need to do the corresponding thing in flatpak. The flatpak build process guarantees that there are the same libraries available in build time as in runtime. Thus, with windows, linux and MacOS covered we should be complete.

Of course, invoking a simple command line tool in Windows requires a python script, it too complicated to just run :)